### PR TITLE
Integer division used explicitly in test mode

### DIFF
--- a/rake.py
+++ b/rake.py
@@ -206,7 +206,7 @@ if test:
 
     totalKeywords = len(sortedKeywords)
     if debug: print(totalKeywords)
-    print(sortedKeywords[0:(totalKeywords / 3)])
+    print(sortedKeywords[0:(totalKeywords // 3)])
 
     rake = Rake("SmartStoplist.txt")
     keywords = rake.run(text)


### PR DESCRIPTION
Division in python3 is automatically converted to floating point, so dividing length by another integer doesn't automatically truncate the result
